### PR TITLE
Fix windows pathseparator on linux

### DIFF
--- a/ProjectReferencesRuler.Tests/ProjectReferencesRuler.Tests.csproj
+++ b/ProjectReferencesRuler.Tests/ProjectReferencesRuler.Tests.csproj
@@ -6,7 +6,7 @@
 
         <RootNamespace>ProjectReferencesRuler</RootNamespace>
 
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectReferencesRuler/ProjectParsing/CsprojReferencesExtractor.cs
+++ b/ProjectReferencesRuler/ProjectParsing/CsprojReferencesExtractor.cs
@@ -29,7 +29,7 @@ namespace ProjectReferencesRuler.ProjectParsing
                 .Where(tuple => !string.IsNullOrEmpty(tuple.Item1))
                 .Select(tuple => new Reference(
                     from: from,
-                    to: Path.GetFileNameWithoutExtension(tuple.Item1),
+                    to: Path.GetFileNameWithoutExtension(CleanPath(tuple.Item1)),
                     isPrivateAssetsAllSet: tuple.Item2 == "All",
                     versionOrNull: null));
         }


### PR DESCRIPTION
Enable Usage of Windows Style PathSeperators in csprojs even when tests running on linux