### PR TITLE
Support slnx

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -11,11 +11,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-    - name: Setup Nuget.exe
-      uses: nuget/setup-nuget@v1
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+      with:
+        dotnet-version: 9.0.x
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Run tests

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owner for all files of the repository
+* @DigitecGalaxus/team-q
+
+# Add specific owners for filetypes or directories following this examples:
+# *.cs for all .cs files
+# /src/ for all subdirectories and files in it
+# /src/* only the files in the specific directory, excluding subdirectories
+# **/logs for all "logs" directories in the repository

--- a/ProjectReferencesRuler.Tests/Dogfooding/ProjectsExistanceCheckTests.cs
+++ b/ProjectReferencesRuler.Tests/Dogfooding/ProjectsExistanceCheckTests.cs
@@ -19,7 +19,7 @@ namespace ProjectReferencesRuler.Dogfooding
                 new SolutionParser(),
                 new CsprojReferencesExtractor());
 
-            var messages = checker.CheckProjectReferencesExistenceInSolution(fullWithoutExternal, "*.csproj").ToList();
+            var messages = checker.CheckProjectReferencesExistenceInSolution(fullWithoutExternal, ".csproj").ToList();
 
             //, $"Check for broken references failed. See messages:\n{string.Join("\n", messages)}"
             Assert.Empty(messages);

--- a/ProjectReferencesRuler.Tests/ProjectReferencesRuler.Tests.csproj
+++ b/ProjectReferencesRuler.Tests/ProjectReferencesRuler.Tests.csproj
@@ -6,7 +6,7 @@
 
         <RootNamespace>ProjectReferencesRuler</RootNamespace>
 
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectReferencesRuler.Tests/SolutionParserTests.cs
+++ b/ProjectReferencesRuler.Tests/SolutionParserTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using ProjectReferencesRuler.SolutionParsing;
@@ -10,12 +11,21 @@ namespace ProjectReferencesRuler
         [Fact]
         public void ExtractProjectPaths_PathInvalid_ThrowsException()
         {
-            var path = "this does not work";
+            var path = "this does not work.sln";
             var solutionParser = new SolutionParser();
 
             var projects = solutionParser.ExtractSolutionProjects(path, ".csproj");
 
             Assert.Throws<FileNotFoundException>(() => projects.ToList());
+        }
+
+        [Fact]
+        public void ExtractProjectPaths_UnknownSolutionType_ThrowsException()
+        {
+            var path = "this does not work.png";
+            var solutionParser = new SolutionParser();
+
+            Assert.Throws<NotSupportedException>(() => solutionParser.ExtractSolutionProjects(path, ".csproj"));
         }
 
         [Fact]
@@ -44,6 +54,25 @@ namespace ProjectReferencesRuler
                     @"../../../TestSolutionFiles/devinite.PortalSystem/devinite.PortalSystem.csproj",
                     @"../../../TestSolutionFiles/CustomerService/Dg.CustomerService.Contracts/Dg.CustomerService.Contracts.csproj",
                     @"../../../TestSolutionFiles/CustomerService/Dg.CustomerService.Monolith/Dg.CustomerService.Monolith.csproj"
+                },
+                paths);
+        }
+
+        [Fact]
+        public void ExtractProjectPaths_SimpleSlnx_ReturnsPaths()
+        {
+            var path = @"../../../TestSolutionFiles/SmallSolution.xml";
+            var solutionParser = new SolutionParser();
+
+            var paths = solutionParser.ExtractSolutionProjects(path, ".csproj").Select(sp => sp.ProjectPath).ToList();
+
+            Assert.NotEmpty(paths);
+            Assert.Equal(
+                new []
+                {
+                    @"../../../TestSolutionFiles/CustomerService/Dg.CustomerService.Contracts/Dg.CustomerService.Contracts.csproj",
+                    @"../../../TestSolutionFiles/CustomerService/Dg.CustomerService.Monolith/Dg.CustomerService.Monolith.csproj",
+                    @"../../../TestSolutionFiles/devinite.PortalSystem/devinite.PortalSystem.csproj"
                 },
                 paths);
         }
@@ -85,9 +114,38 @@ namespace ProjectReferencesRuler
         }
 
         [Fact]
+        public void ExtractProjectPaths_SlnxWithFolders_ReturnsOnlyProjectPaths()
+        {
+            var path = @"../../../TestSolutionFiles/SolutionWithFolders.xml";
+            var solutionParser = new SolutionParser();
+
+            var paths = solutionParser.ExtractSolutionProjects(path, ".csproj").Select(sp => sp.ProjectPath).ToList();
+
+            Assert.NotEmpty(paths);
+            Assert.Equal(
+                new []
+                {
+                    @"../../../TestSolutionFiles/devinite.PortalSystem/devinite.PortalSystem.csproj",
+                },
+                paths);
+        }
+
+        [Fact]
         public void ExtractProjectPaths_LargeSolution_ParsesWithoutErrors()
         {
             var path = @"../../../TestSolutionFiles/LargeSolution.txt";
+            var solutionParser = new SolutionParser();
+
+            var projects = solutionParser.ExtractSolutionProjects(path, ".csproj").ToList();
+
+            Assert.NotEmpty(projects);
+            Assert.Equal(142, projects.Count);
+        }
+
+        [Fact]
+        public void ExtractProjectPaths_LargeSolutionSlnx_ParsesWithoutErrors()
+        {
+            var path = @"../../../TestSolutionFiles/LargeSolution.xml";
             var solutionParser = new SolutionParser();
 
             var projects = solutionParser.ExtractSolutionProjects(path, ".csproj").ToList();

--- a/ProjectReferencesRuler.Tests/SolutionParserTests.cs
+++ b/ProjectReferencesRuler.Tests/SolutionParserTests.cs
@@ -19,14 +19,14 @@ namespace ProjectReferencesRuler
         }
 
         [Fact]
-        public void ExtractProjectPaths_NoLineStartsWithProject_ReturnsEmptyEnumerable()
+        public void ExtractProjectPaths_NoLineStartsWithProject_ThrowsException()
         {
             var path = @"../../../TestSolutionFiles/README.txt";
             var solutionParser = new SolutionParser();
 
             var projects = solutionParser.ExtractSolutionProjects(path, ".csproj");
 
-            Assert.Empty(projects);
+            Assert.Throws<InvalidOperationException>(() => projects.ToList());
         }
 
         [Fact]

--- a/ProjectReferencesRuler.Tests/TestSolutionFiles/LargeSolution.xml
+++ b/ProjectReferencesRuler.Tests/TestSolutionFiles/LargeSolution.xml
@@ -1,0 +1,226 @@
+<Solution>
+  <Configurations>
+    <Platform Name="Any CPU" />
+    <Platform Name="x64" />
+    <Platform Name="x86" />
+  </Configurations>
+  <Folder Name="/Applications/">
+    <Project Path="Applications/Dg.MessageHandlers.WindowsService/Dg.MessageHandlers.WindowsService.csproj" />
+  </Folder>
+  <Folder Name="/CategoryManagement/">
+    <Project Path="CategoryManagement/Dg.CategoryManagement.Erp/Dg.CategoryManagement.Erp.csproj">
+      <Build Solution="Release|x86" Project="false" />
+    </Project>
+    <Project Path="CategoryManagement/Dg.CategoryManagement.InversionOfControl/Dg.CategoryManagement.InversionOfControl.csproj" />
+    <Project Path="CategoryManagement/Dg.CategoryManagement.SystemTasks/Dg.CategoryManagement.SystemTasks.csproj" />
+    <Project Path="CategoryManagement/Dg.CategoryManagement.TestsWithDb/Dg.CategoryManagement.TestsWithDb.csproj" />
+    <Project Path="CategoryManagement/Dg.CategoryManagement.TestsWithoutDb/Dg.CategoryManagement.TestsWithoutDb.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductCatalog.Contracts/Dg.ProductCatalog.Contracts.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductCatalog/Dg.ProductCatalog.csproj" />
+  </Folder>
+  <Folder Name="/CategoryManagement/Dg.ProductForecast/">
+    <File Path="Monolith.Contracts/Dg.OnlineShop/Dg.ShopProductCatalog.ruleset" />
+    <Project Path="CategoryManagement/Dg.ProductForecast/Dg.ProductForecast.Contracts/Dg.ProductForecast.Contracts.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductForecast/Dg.ProductForecast.DataAccess/Dg.ProductForecast.DataAccess.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductForecast/Dg.ProductForecast.InversionOfControl/Dg.ProductForecast.InversionOfControl.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductForecast/Dg.ProductForecast.TestsWithoutDb/Dg.ProductForecast.TestsWithoutDb.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductForecast/Dg.ProductForecast.TestWithDb/Dg.ProductForecast.TestWithDb.csproj" />
+    <Project Path="CategoryManagement/Dg.ProductForecast/Dg.ProductForecast/Dg.ProductForecast.csproj" />
+  </Folder>
+  <Folder Name="/CategoryManagement/Dg.PurchaseProposal/">
+    <Project Path="CategoryManagement/Dg.PurchaseProposal/Dg.PurchaseProposal.Contracts/Dg.PurchaseProposal.Contracts.csproj" />
+    <Project Path="CategoryManagement/Dg.PurchaseProposal/Dg.PurchaseProposal.DataAccess/Dg.PurchaseProposal.DataAccess.csproj" />
+    <Project Path="CategoryManagement/Dg.PurchaseProposal/Dg.PurchaseProposal.InversionOfControl/Dg.PurchaseProposal.InversionOfControl.csproj" />
+    <Project Path="CategoryManagement/Dg.PurchaseProposal/Dg.PurchaseProposal.TestsWithDb/Dg.PurchaseProposal.TestsWithDb.csproj" />
+    <Project Path="CategoryManagement/Dg.PurchaseProposal/Dg.PurchaseProposal.TestsWithoutDb/Dg.PurchaseProposal.TestsWithoutDb.csproj" />
+    <Project Path="CategoryManagement/Dg.PurchaseProposal/Dg.PurchaseProposal/Dg.PurchaseProposal.csproj" />
+  </Folder>
+  <Folder Name="/CategoryManagement/Dg.Sales/">
+    <Project Path="CategoryManagement/Dg.Sales/Dg.Sales.Contracts/Dg.Sales.Contracts.csproj" />
+    <Project Path="CategoryManagement/Dg.Sales/Dg.Sales.InversionOfControl/Dg.Sales.InversionOfControl.csproj" />
+    <Project Path="CategoryManagement/Dg.Sales/Dg.Sales/Dg.Sales.csproj" />
+  </Folder>
+  <Folder Name="/CategoryManagement/Monolith/">
+    <Project Path="CategoryManagement/Monolith/Dg.CategoryManagement.Monolith.Contracts/Dg.CategoryManagement.Monolith.Contracts.csproj" />
+    <Project Path="CategoryManagement/Monolith/Dg.CategoryManagement.Monolith/Dg.CategoryManagement.Monolith.csproj" />
+  </Folder>
+  <Folder Name="/Chabis/">
+    <Project Path="Chabis.DbCache.InversionOfControl.SimpleInjector/Chabis.DbCache.InversionOfControl.SimpleInjector.csproj" />
+    <Project Path="Chabis.DbCache.TestsWithoutDb/Chabis.DbCache.TestsWithoutDb.csproj" />
+    <Project Path="Chabis.DbCache/Chabis.DbCache.csproj" />
+    <Project Path="Chabis.Mail/Chabis.Mail.csproj" />
+  </Folder>
+  <Folder Name="/CustomerService/">
+    <Project Path="CustomerService/Dg.CustomerService.Contracts/Dg.CustomerService.Contracts.csproj" />
+    <Project Path="CustomerService/Dg.CustomerService.Monolith/Dg.CustomerService.Monolith.csproj" />
+    <Project Path="CustomerService/Dg.CustomerService/Dg.CustomerService.csproj" />
+  </Folder>
+  <Folder Name="/Dg.DgConsolidate/">
+    <Project Path="Dg.DgConsolidate/Dg.DgConsolidate.csproj" />
+    <Project Path="Dg.DgConsolidateNet461/Dg.DgConsolidateNet461.csproj" />
+    <Project Path="Dg.InversionOfControl/Dg.InversionOfControl.csproj" />
+  </Folder>
+  <Folder Name="/Erp/">
+    <Project Path="devinite.PortalSystem.Erp/devinite.PortalSystem.Erp.csproj" />
+  </Folder>
+  <Folder Name="/FeatureToggle/">
+    <Project Path="Dg.FeatureToggle.DataAccess/Dg.FeatureToggle.DataAccess.csproj" />
+    <Project Path="Dg.FeatureToggle/Dg.FeatureToggle.csproj" />
+  </Folder>
+  <Folder Name="/Finance/">
+    <Project Path="Finance/Dg.Finance.Erp/Dg.Finance.Erp.csproj" />
+    <Project Path="Finance/Dg.Finance.TestsWithDb/Dg.Finance.TestsWithDb.csproj" />
+    <Project Path="Finance/Dg.Finance.TestsWithoutDb/Dg.Finance.TestsWithoutDb.csproj" />
+  </Folder>
+  <Folder Name="/Finance/Dg.PaymentServices/">
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.Contracts/Dg.PaymentServices.Contracts.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.DataAccess/Dg.PaymentServices.DataAccess.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.InversionOfControl/Dg.PaymentServices.InversionOfControl.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.MaterializedView.Contracts/Dg.PaymentServices.MaterializedView.Contracts.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.MaterializedView/Dg.PaymentServices.MaterializedView.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.TestsWithDb/Dg.PaymentServices.TestsWithDb.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices.TestsWithoutDb/Dg.PaymentServices.TestsWithoutDb.csproj" />
+    <Project Path="Finance/Dg.PaymentServices/Dg.PaymentServices/Dg.PaymentServices.csproj" />
+  </Folder>
+  <Folder Name="/Finance/Monolith/">
+    <Project Path="Finance/Monolith/Dg.Finance.Monolith.Contracts/Dg.Finance.Monolith.Contracts.csproj" />
+    <Project Path="Finance/Monolith/Dg.Finance.Monolith/Dg.Finance.Monolith.csproj" />
+  </Folder>
+  <Folder Name="/Framework/">
+    <Project Path="Framework/Dg.Erp.Framework/Dg.Erp.Framework.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/">
+    <File Path="Logistics/Dg.Logistics.ruleset" />
+    <Project Path="Logistics/Dg.Logistics.Erp/Dg.Logistics.Erp.csproj" />
+    <Project Path="Logistics/Dg.Logistics.InversionOfControl/Dg.Logistics.InversionOfControl.csproj" />
+    <Project Path="Logistics/Dg.Logistics.MessageHandlers/Dg.Logistics.MessageHandlers.csproj" />
+    <Project Path="Logistics/Dg.Logistics.Mli/Dg.Logistics.Mli.csproj" />
+    <Project Path="Logistics/Dg.Logistics.Monolith.DataExchange/Dg.Logistics.Monolith.DataExchange.csproj" />
+    <Project Path="Logistics/Dg.Logistics.Purgatory.Erp/Dg.Logistics.Purgatory.Erp.csproj" />
+    <Project Path="Logistics/Dg.Logistics.SystemTasks/Dg.Logistics.SystemTasks.csproj" />
+    <Project Path="Logistics/Dg.Logistics.TestsWithDb/Dg.Logistics.TestsWithDb.csproj" />
+    <Project Path="Logistics/Dg.Logistics.TestsWithoutDb/Dg.Logistics.TestsWithoutDb.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/ArticleRouting/">
+    <Project Path="Logistics/ArticleRouting/Dg.ArticleRouting.Contracts/Dg.ArticleRouting.Contracts.csproj" />
+    <Project Path="Logistics/ArticleRouting/Dg.ArticleRouting/Dg.ArticleRouting.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/IncomingParcelRouting/">
+    <Project Path="Logistics/IncomingParcelRouting/Dg.IncomingParcelRouting.Contracts/Dg.IncomingParcelRouting.Contracts.csproj" />
+    <Project Path="Logistics/IncomingParcelRouting/Dg.IncomingParcelRouting/Dg.IncomingParcelRouting.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/LogisticsProductCatalog/">
+    <Project Path="Logistics/LogisticsProductCatalog/Dg.LogisticsProductCatalog.Contracts/Dg.LogisticsProductCatalog.Contracts.csproj" />
+    <Project Path="Logistics/LogisticsProductCatalog/Dg.LogisticsProductCatalog/Dg.LogisticsProductCatalog.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/Monolith/">
+    <Project Path="Logistics/Monolith/Dg.Logistics.Monolith.Contracts/Dg.Logistics.Monolith.Contracts.csproj" />
+    <Project Path="Logistics/Monolith/Dg.Logistics.Monolith/Dg.Logistics.Monolith.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/ParcelShipping/">
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping.Contracts/Dg.ParcelShipping.Contracts.csproj" />
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping.DataAccess/Dg.ParcelShipping.DataAccess.csproj" />
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping.DhlStreetCodeSearch.ConsoleApplication/Dg.ParcelShipping.DhlStreetCodeSearch.ConsoleApplication.csproj" />
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping.DhlStreetCodeSearch/Dg.ParcelShipping.DhlStreetCodeSearch.csproj" />
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping.InversionOfControl/Dg.ParcelShipping.InversionOfControl.csproj" />
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping.MaterializedView/Dg.ParcelShipping.MaterializedView.csproj" />
+    <Project Path="Logistics/ParcelShipping/Dg.ParcelShipping/Dg.ParcelShipping.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/Returns/">
+    <Project Path="Logistics/Returns/Dg.Returns.Contracts/Dg.Returns.Contracts.csproj" />
+    <Project Path="Logistics/Returns/Dg.Returns/Dg.Returns.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/StorageArea/">
+    <Project Path="Logistics/StorageArea/Dg.StorageArea.Contracts/Dg.StorageArea.Contracts.csproj" />
+    <Project Path="Logistics/StorageArea/Dg.StorageArea/Dg.StorageArea.csproj" />
+  </Folder>
+  <Folder Name="/Logistics/Wms/">
+    <Project Path="Logistics/Wms/Dg.Wms.Api/Dg.Wms.Api.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms.DataAccess.Erp2Wms/Dg.Wms.DataAccess.Erp2Wms.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms.DataAccess.Wms2Erp/Dg.Wms.DataAccess.Wms2Erp.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms.DataAccess/Dg.Wms.DataAccess.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms.Erp/Dg.Wms.Erp.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms.InterfaceService/Dg.Wms.InterfaceService.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms.PollingService/Dg.Wms.PollingService.csproj" />
+    <Project Path="Logistics/Wms/Dg.Wms/Dg.Wms.csproj" />
+  </Folder>
+  <Folder Name="/Meta/">
+    <Project Path="devinite.Meta.Db/devinite.Meta.Db.csproj" />
+  </Folder>
+  <Folder Name="/MobileLogistics/">
+    <Project Path="devinite.PortalSystem.MobileLogistics/devinite.PortalSystem.MobileLogistics.csproj" />
+  </Folder>
+  <Folder Name="/Monolith.Contracts/">
+    <Project Path="Monolith.Contracts/Dg.Monolith.Contracts.TestsWithoutDb/Dg.Monolith.Contracts.TestsWithoutDb.csproj" />
+  </Folder>
+  <Folder Name="/Monolith.Contracts/Dg.HumanResources/">
+    <File Path="CategoryManagement/Dg.ProductCatalog.ruleset" />
+    <Project Path="Monolith.Contracts/Dg.HumanResources/Dg.HumanResources.Contracts/Dg.HumanResources.Contracts.csproj" />
+    <Project Path="Monolith.Contracts/Dg.HumanResources/Dg.HumanResources/Dg.HumanResources.csproj" />
+  </Folder>
+  <Folder Name="/Monolith.Contracts/Dg.OnlineShop/">
+    <Project Path="Dg.OnlineShop.InversionOfControl/Dg.OnlineShop.InversionOfControl.csproj" />
+    <Project Path="Monolith.Contracts/Dg.OnlineShop/Dg.ShopProductCatalog.Contracts/Dg.ShopProductCatalog.Contracts.csproj" />
+    <Project Path="Monolith.Contracts/Dg.OnlineShop/Dg.ShopProductCatalog/Dg.ShopProductCatalog.csproj" />
+  </Folder>
+  <Folder Name="/Newsletter/">
+    <Project Path="Dg.Newsletter.Contracts/Dg.Newsletter.Contracts.csproj" />
+    <Project Path="Dg.Newsletter.DataAccess/Dg.Newsletter.DataAccess.csproj" />
+    <Project Path="Dg.Newsletter.InversionOfControl/Dg.Newsletter.InversionOfControl.csproj" />
+    <Project Path="Dg.Newsletter/Dg.Newsletter.csproj" />
+  </Folder>
+  <Folder Name="/Personalization/">
+    <Project Path="Dg.Personalization.Test/Dg.Personalization.Test.csproj" />
+    <Project Path="Dg.Personalization/Dg.Personalization.csproj" />
+  </Folder>
+  <Folder Name="/Rma/">
+    <Project Path="Rma/Dg.Rma.Contracts/Dg.Rma.Contracts.csproj" />
+    <Project Path="Rma/Dg.Rma.Erp/Dg.Rma.Erp.csproj" />
+    <Project Path="Rma/Dg.Rma.InversionOfControl/Dg.Rma.InversionOfControl.csproj" />
+    <Project Path="Rma/Dg.Rma.Monolith/Dg.Rma.Monolith.csproj" />
+    <Project Path="Rma/Dg.Rma.TestsWithDb/Dg.Rma.TestsWithDb.csproj" />
+    <Project Path="Rma/Dg.Rma.TestsWithoutDb/Dg.Rma.TestsWithoutDb.csproj" />
+    <Project Path="Rma/Dg.Rma/Dg.Rma.csproj" />
+  </Folder>
+  <Folder Name="/Shop/">
+    <Project Path="devinite.PortalSystem.Shop/devinite.PortalSystem.Shop.csproj" />
+    <Project Path="Dg.OnlineShop.Website/Dg.OnlineShop.Website.csproj" />
+  </Folder>
+  <Folder Name="/System/">
+    <Project Path="System/Dg.System.Erp/Dg.System.Erp.csproj" />
+    <Project Path="System/Monolith/Dg.System.Monolith.Contracts/Dg.System.Monolith.Contracts.csproj" />
+    <Project Path="System/Monolith/Dg.System.Monolith/Dg.System.Monolith.csproj" />
+  </Folder>
+  <Folder Name="/SystemTasks/">
+    <Project Path="devinite.SystemTasks.Core/devinite.SystemTasks.Core.csproj" />
+    <Project Path="devinite.SystemTasks/devinite.SystemTasks.csproj" />
+    <Project Path="devinite.SystemTasksManager/devinite.SystemTasksManager.csproj" />
+    <Project Path="devinite.SystemTasksService/devinite.SystemTasksService.csproj" />
+  </Folder>
+  <Project Path="devinite.ClassLibrary.Core/devinite.ClassLibrary.Core.csproj" />
+  <Project Path="devinite.ClassLibrary/devinite.ClassLibrary.csproj" />
+  <Project Path="devinite.ConsoleApplicationForDebugging/devinite.ConsoleApplicationForDebugging.csproj">
+    <BuildDependency Project="devinite.PortalSystem.Shop/devinite.PortalSystem.Shop.csproj" />
+  </Project>
+  <Project Path="devinite.DataExchange/devinite.DataExchange.csproj" />
+  <Project Path="devinite.Db/devinite.Db.csproj" />
+  <Project Path="devinite.PortalSystem.ClassLibrary/devinite.PortalSystem.ClassLibrary.csproj" />
+  <Project Path="devinite.PortalSystem.Cmi/devinite.PortalSystem.Cmi.csproj" />
+  <Project Path="devinite.PortalSystem.Retail/devinite.PortalSystem.Retail.csproj" />
+  <Project Path="devinite.PortalSystem.Test/devinite.PortalSystem.Test.csproj" />
+  <Project Path="devinite.PortalSystem/devinite.PortalSystem.csproj" />
+  <Project Path="devinite.PrinterService/devinite.PrinterService.csproj" />
+  <Project Path="devinite.QualityMonitoring/devinite.QualityMonitoring.csproj" />
+  <Project Path="devinite.Testing.Common/devinite.Testing.Common.csproj" />
+  <Project Path="devinite.Testing.Integration/devinite.Testing.Integration.csproj" />
+  <Project Path="devinite.Testing.Unit/devinite.Testing.Unit.csproj" />
+  <Project Path="Dg.Application.Abstractions/Dg.Application.Abstractions.csproj" />
+  <Project Path="Dg.DbCache.DataAccess/Dg.DbCache.DataAccess.csproj" />
+  <Project Path="Dg.DbCache/Dg.DbCache.csproj" />
+  <Project Path="Dg.OnlineShop.TestsWithDb/Dg.OnlineShop.TestsWithDb.csproj" />
+  <Project Path="Dg.OnlineShop.TestsWithoutDb/Dg.OnlineShop.TestsWithoutDb.csproj" />
+  <Project Path="Dg.ShopProductBoxRepository/Dg.ShopProductBoxRepository.csproj" />
+  <Project Path="Dg.TestsWithDb/Dg.TestsWithDb.csproj" />
+  <Project Path="Dg.TestsWithoutDb/Dg.TestsWithoutDb.csproj" />
+  <Project Path="Dg.Web.Abstractions/Dg.Web.Abstractions.csproj" />
+</Solution>

--- a/ProjectReferencesRuler.Tests/TestSolutionFiles/README.txt
+++ b/ProjectReferencesRuler.Tests/TestSolutionFiles/README.txt
@@ -1,2 +1,2 @@
-Here are just some example solution files for unit tests. They are renamed to be TXTs in order
+Here are just some example solution files for unit tests. They are renamed to be TXTs / XMLs in order
 not to confuse the IDE. Please don't judge files by content. They are just examples.

--- a/ProjectReferencesRuler.Tests/TestSolutionFiles/SmallInvalidTestSolution.xml
+++ b/ProjectReferencesRuler.Tests/TestSolutionFiles/SmallInvalidTestSolution.xml
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="../TestProjectFiles/Dg.Component.Contracts.xml" Type="C#" />
+  <Project Path="../TestProjectFiles/Dg.Returns.xml" Type="C#" />
+</Solution>

--- a/ProjectReferencesRuler.Tests/TestSolutionFiles/SmallSolution.xml
+++ b/ProjectReferencesRuler.Tests/TestSolutionFiles/SmallSolution.xml
@@ -1,0 +1,5 @@
+<Solution>
+  <Project Path="CustomerService/Dg.CustomerService.Contracts/Dg.CustomerService.Contracts.csproj" />
+  <Project Path="CustomerService/Dg.CustomerService.Monolith/Dg.CustomerService.Monolith.csproj" />
+  <Project Path="devinite.PortalSystem/devinite.PortalSystem.csproj" />
+</Solution>

--- a/ProjectReferencesRuler.Tests/TestSolutionFiles/SmallValidTestSolution.xml
+++ b/ProjectReferencesRuler.Tests/TestSolutionFiles/SmallValidTestSolution.xml
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="../TestProjectFiles/Dg.Component.Contracts.xml" Type="C#" />
+  <Project Path="../TestProjectFiles/Dg.Component.xml" Type="C#" />
+</Solution>

--- a/ProjectReferencesRuler.Tests/TestSolutionFiles/SolutionWithFolders.xml
+++ b/ProjectReferencesRuler.Tests/TestSolutionFiles/SolutionWithFolders.xml
@@ -1,0 +1,4 @@
+<Solution>
+  <Folder Name="/Dg.DgConsolidate/" />
+  <Project Path="devinite.PortalSystem/devinite.PortalSystem.csproj" />
+</Solution>

--- a/ProjectReferencesRuler/ProjectParsing/CsprojReferencesExtractor.cs
+++ b/ProjectReferencesRuler/ProjectParsing/CsprojReferencesExtractor.cs
@@ -54,7 +54,8 @@ namespace ProjectReferencesRuler.ProjectParsing
             return projectReferenceItemGroup
                 .ElementsIgnoreNamespace(ProjectReference)
                 .Select(GetIncludeContent)
-                .Where(r => !string.IsNullOrEmpty(r));
+                .Where(r => !string.IsNullOrEmpty(r))
+                .Select(CleanPath);
         }
 
         private static XDocument ParseXml(string csprojPath)

--- a/ProjectReferencesRuler/ProjectReferencesRuler.csproj
+++ b/ProjectReferencesRuler/ProjectReferencesRuler.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/ProjectReferencesRuler/SolutionParsing/SolutionParser.cs
+++ b/ProjectReferencesRuler/SolutionParsing/SolutionParser.cs
@@ -8,7 +8,8 @@ namespace ProjectReferencesRuler.SolutionParsing
     {
         public IEnumerable<SolutionProject> ExtractSolutionProjects(string solutionPath, string projectFileExtension)
         {
-            var solutionDir = Path.GetDirectoryName(CleanPath(solutionPath));
+            bool atLeastOneReferenceFound = false;
+            var solutionDir = Path.GetDirectoryName(CleanPath(solutionPath))!;
             foreach (var line in File.ReadLines(CleanPath(solutionPath)))
             {
                 if (line.StartsWith("Project"))
@@ -17,12 +18,18 @@ namespace ProjectReferencesRuler.SolutionParsing
                     var projectGuid = CleanPath(ParseProjectGuid(line));
                     if (projectPath != null && projectPath.EndsWith(projectFileExtension, StringComparison.InvariantCultureIgnoreCase))
                     {
+                        atLeastOneReferenceFound = true;
                         yield return new SolutionProject(
                             projectGuid: projectGuid,
                             projectPath: CleanPath(Path.Combine(solutionDir, projectPath)),
                             isFolder: projectGuid == "2150E333-8FDC-42A3-9474-1A3956D46DE8");
                     }
                 }
+            }
+
+            if (!atLeastOneReferenceFound)
+            {
+                throw new InvalidOperationException($"No project references were found in the solution {solutionPath}.");
             }
         }
 

--- a/ProjectReferencesRuler/SolutionParsing/SolutionParser.cs
+++ b/ProjectReferencesRuler/SolutionParsing/SolutionParser.cs
@@ -1,12 +1,25 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Xml;
 
 namespace ProjectReferencesRuler.SolutionParsing
 {
     public class SolutionParser : ISolutionParser
     {
         public IEnumerable<SolutionProject> ExtractSolutionProjects(string solutionPath, string projectFileExtension)
+        {
+            return Path.GetExtension(solutionPath).ToLowerInvariant() switch
+            {
+                // .xml and .txt are used for tests
+                ".slnx" or ".xml" => ExtractNewSolutionProjects(solutionPath, projectFileExtension),
+                ".sln" or ".txt" => ExtractClassicSolutionProjects(solutionPath, projectFileExtension),
+                _ => throw new NotSupportedException($"Solution type not supported: {solutionPath}")
+            };
+        }
+
+        private IEnumerable<SolutionProject> ExtractClassicSolutionProjects(string solutionPath, string projectFileExtension)
         {
             bool atLeastOneReferenceFound = false;
             var solutionDir = Path.GetDirectoryName(CleanPath(solutionPath))!;
@@ -31,6 +44,27 @@ namespace ProjectReferencesRuler.SolutionParsing
             {
                 throw new InvalidOperationException($"No project references were found in the solution {solutionPath}.");
             }
+        }
+
+        private IEnumerable<SolutionProject> ExtractNewSolutionProjects(string solutionPath, string projectFileExtension)
+        {
+            var solutionDir = Path.GetDirectoryName(CleanPath(solutionPath))!;
+            var doc = new XmlDocument();
+            doc.Load(solutionPath);
+
+            var projects = doc.GetElementsByTagName("Project")
+                .OfType<XmlNode>()
+                .Select(e => e.Attributes?["Path"].Value)
+                .Where(p => !string.IsNullOrEmpty(p) && p.EndsWith(projectFileExtension, StringComparison.InvariantCultureIgnoreCase))
+                .Select(p => new SolutionProject("", CleanPath(Path.Combine(solutionDir, p)), false))
+                .ToList();
+
+            if (!projects.Any())
+            {
+                throw new InvalidOperationException($"No project references were found in the solution {solutionPath}.");
+            }
+
+            return projects;
         }
 
         private string ParseProjectGuid(string line)


### PR DESCRIPTION
* Support slnx (test-data generated with `dotnet sln migrate`)
* Throw if no project references are found (otherwise it's really easy to accidentally end up with no checks)
* Fix path cleanup for project references (Windows-style references were not properly normalized under Linux)
* Set Team Q as code owner