### PR TITLE
Deduplicate CleanPath helper

### DIFF
--- a/ProjectReferencesRuler/PathNormalizer.cs
+++ b/ProjectReferencesRuler/PathNormalizer.cs
@@ -1,0 +1,13 @@
+namespace ProjectReferencesRuler
+{
+    internal static class PathNormalizer
+    {
+        /// <summary>
+        /// Replaces \ with / so the same code works on both Windows and Linux.
+        /// </summary>
+        public static string CleanPath(string path)
+        {
+            return path.Replace("\\", "/");
+        }
+    }
+}

--- a/ProjectReferencesRuler/ProjectParsing/CsprojReferencesExtractor.cs
+++ b/ProjectReferencesRuler/ProjectParsing/CsprojReferencesExtractor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Xml.Linq;
 using ProjectReferencesRuler.Rules.Project;
 using ProjectReferencesRuler.Rules.References;
+using static ProjectReferencesRuler.PathNormalizer;
 
 namespace ProjectReferencesRuler.ProjectParsing
 {
@@ -72,14 +73,6 @@ namespace ProjectReferencesRuler.ProjectParsing
                 name: CleanPath(Path.GetFileNameWithoutExtension(csprojPath)),
                 importedProps: GetImportedProps(doc).Select(CleanPath).ToList(),
                 targetFrameworks: GetTargetFrameworks(doc).ToList());
-        }
-
-        /// <summary>
-        /// Replaces \ with / in order for this same code to work on both Windows and Linux.
-        /// </summary>
-        private static string CleanPath(string path)
-        {
-            return path.Replace("\\", "/");
         }
 
         private IEnumerable<string> GetTargetFrameworks(XDocument doc)

--- a/ProjectReferencesRuler/SolutionParsing/SolutionParser.cs
+++ b/ProjectReferencesRuler/SolutionParsing/SolutionParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using static ProjectReferencesRuler.PathNormalizer;
 
 namespace ProjectReferencesRuler.SolutionParsing
 {
@@ -87,14 +88,6 @@ namespace ProjectReferencesRuler.SolutionParsing
 
             // removes the parenthesis
             return pathInParenthesis.Trim().Substring(1, pathInParenthesis.Length - 3);
-        }
-
-        /// <summary>
-        /// Replaces \ with / in order for this same code to work on both Windows and Linux.
-        /// </summary>
-        private static string CleanPath(string path)
-        {
-            return path.Replace("\\", "/");
         }
     }
 }


### PR DESCRIPTION
The same `path.Replace("\\", "/")` helper lived in both CsprojReferencesExtractor and SolutionParser. Extract it to a single internal `PathNormalizer.CleanPath` and `using static` it from both call sites so usages stay unchanged.